### PR TITLE
Use maven-antrun-plugin 3.0.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -389,7 +389,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-antrun-plugin</artifactId>
-		<version>3.0.0</version>
+                <version>3.0.0</version>
                 <dependencies>
                     <dependency>
                         <groupId>org.apache.ant</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -389,15 +389,8 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-antrun-plugin</artifactId>
-                <version>1.8</version>
+		<version>3.0.0</version>
                 <dependencies>
-                    <dependency>
-                        <groupId>com.sun</groupId>
-                        <artifactId>tools</artifactId>
-                        <version>1.5.0</version>
-                        <scope>system</scope>
-                        <systemPath>${java.home}/../lib/tools.jar</systemPath>
-                    </dependency>
                     <dependency>
                         <groupId>org.apache.ant</groupId>
                         <artifactId>ant-junit</artifactId>

--- a/src/main/java/com/licel/jcardsim/crypto/ByteContainer.java
+++ b/src/main/java/com/licel/jcardsim/crypto/ByteContainer.java
@@ -106,7 +106,7 @@ public final class ByteContainer {
      * @param length length of data in byte array
      */
     public void setBytes(byte[] buff, short offset, short length) {
-        if (data == null) {
+        if (data == null || this.length != length) {
             switch (memoryType) {
                 case JCSystem.MEMORY_TYPE_TRANSIENT_DESELECT:
                     data = JCSystem.makeTransientByteArray(length, JCSystem.CLEAR_ON_DESELECT);


### PR DESCRIPTION
Building jcardsim with more recent JDK fails because tools.jar is missing starting with JDK11.
Updating maven-antrun-plugin seems to resolve this issue.